### PR TITLE
Make table columns responsive within themselves

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -150,9 +150,9 @@ func run() {
 
 		// display header
 		headerCells := []string{
-			style.CommandStyle().Render(pkg.TruncateText(header[0], columnWidths.Command)),
-			style.ContentStyle().Render(pkg.TruncateText(header[1], columnWidths.Content)),
-			style.DescriptionStyle().Render(pkg.TruncateText(header[2], columnWidths.Description)),
+			style.CommandStyle().Render(pkg.NormalizeAndFitText(header[0], columnWidths.Command)),
+			style.ContentStyle().Render(pkg.NormalizeAndFitText(header[1], columnWidths.Content)),
+			style.DescriptionStyle().Render(pkg.NormalizeAndFitText(header[2], columnWidths.Description)),
 		}
 		fmt.Print(lipgloss.JoinHorizontal(lipgloss.Left, headerCells...))
 		fmt.Print("\n")
@@ -160,9 +160,9 @@ func run() {
 		// display data
 		for _, datum := range datums {
 			row := []string{
-				style.CommandStyle().Render(pkg.TruncateText(datum.Command, columnWidths.Command)),
-				style.ContentStyle().Render(pkg.TruncateText(datum.Content, columnWidths.Content)),
-				style.DescriptionStyle().Render(pkg.TruncateText(datum.Description, columnWidths.Description)),
+				style.CommandStyle().Render(pkg.NormalizeAndFitText(datum.Command, columnWidths.Command)),
+				style.ContentStyle().Render(pkg.NormalizeAndFitText(datum.Content, columnWidths.Content)),
+				style.DescriptionStyle().Render(pkg.NormalizeAndFitText(datum.Description, columnWidths.Description)),
 			}
 			fmt.Print(lipgloss.JoinHorizontal(lipgloss.Left, row...))
 			fmt.Print("\n")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -150,9 +150,9 @@ func run() {
 
 		// display header
 		headerCells := []string{
-			style.CommandStyle().Render(header[0]),
-			style.ContentStyle().Render(header[1]),
-			style.DescriptionStyle().Render(header[2]),
+			style.CommandStyle().Render(pkg.TruncateText(header[0], columnWidths.Command)),
+			style.ContentStyle().Render(pkg.TruncateText(header[1], columnWidths.Content)),
+			style.DescriptionStyle().Render(pkg.TruncateText(header[2], columnWidths.Description)),
 		}
 		fmt.Print(lipgloss.JoinHorizontal(lipgloss.Left, headerCells...))
 		fmt.Print("\n")
@@ -160,9 +160,9 @@ func run() {
 		// display data
 		for _, datum := range datums {
 			row := []string{
-				style.CommandStyle().Render(datum.Command),
-				style.ContentStyle().Render(datum.Content),
-				style.DescriptionStyle().Render(datum.Description),
+				style.CommandStyle().Render(pkg.TruncateText(datum.Command, columnWidths.Command)),
+				style.ContentStyle().Render(pkg.TruncateText(datum.Content, columnWidths.Content)),
+				style.DescriptionStyle().Render(pkg.TruncateText(datum.Description, columnWidths.Description)),
 			}
 			fmt.Print(lipgloss.JoinHorizontal(lipgloss.Left, row...))
 			fmt.Print("\n")

--- a/pkg/style.go
+++ b/pkg/style.go
@@ -122,32 +122,16 @@ func (s *Style) DescriptionStyle() lipgloss.Style {
 // If text is longer than width, it will be truncated with "..." at the end
 // This function considers the display width (full-width characters count as 2)
 func TruncateText(text string, width int) string {
-	// 改行、タブ、連続する空白を単一のスペースに置き換える
-	text = strings.ReplaceAll(text, "\n", " ")
-	text = strings.ReplaceAll(text, "\t", " ")
+	// Normalize whitespace by replacing newlines, tabs, and multiple spaces with a single space.
 	text = strings.Join(strings.Fields(text), " ")
-	
-	// パディングを考慮して実際の利用可能幅を計算（左右1文字ずつのパディング）
+
+	// Calculate available width considering 1-char padding on each side.
 	availableWidth := width - 2
-	if availableWidth <= 0 {
-		return text
+	if availableWidth < 0 {
+		availableWidth = 0
 	}
-	
-	// 表示幅を計算（全角文字は2、半角文字は1としてカウント）
-	textWidth := runewidth.StringWidth(text)
-	if textWidth <= availableWidth {
-		return text
-	}
-	
-	// "..."の表示幅（3文字）を確保
-	if availableWidth <= 3 {
-		return "..."
-	}
-	
-	// 利用可能な幅から"..."の分を引く
-	targetWidth := availableWidth - 3
-	
-	// 表示幅に基づいてテキストを切り詰める
-	truncated := runewidth.Truncate(text, targetWidth, "")
-	return truncated + "..."
+
+	// Truncate the text and add an ellipsis if it's too long.
+	// runewidth.Truncate handles cases where the text fits and does not need truncation.
+	return runewidth.Truncate(text, availableWidth, "...")
 }

--- a/pkg/style.go
+++ b/pkg/style.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
 )
 
 const (
@@ -92,6 +93,7 @@ func (s *Style) CommandStyle() lipgloss.Style {
 		Background(ContentBg).
 		Bold(true).
 		Width(s.widths.Command).
+		MaxWidth(s.widths.Command).
 		PaddingLeft(1).
 		PaddingRight(1)
 }
@@ -101,6 +103,7 @@ func (s *Style) ContentStyle() lipgloss.Style {
 		Foreground(TextColor).
 		Background(ContentBg).
 		Width(s.widths.Content).
+		MaxWidth(s.widths.Content).
 		PaddingLeft(1).
 		PaddingRight(1)
 }
@@ -110,6 +113,41 @@ func (s *Style) DescriptionStyle() lipgloss.Style {
 		Foreground(TextColor).
 		Background(ContentBg).
 		Width(s.widths.Description).
+		MaxWidth(s.widths.Description).
 		PaddingLeft(1).
 		PaddingRight(1)
+}
+
+// TruncateText truncates text to fit within the specified width
+// If text is longer than width, it will be truncated with "..." at the end
+// This function considers the display width (full-width characters count as 2)
+func TruncateText(text string, width int) string {
+	// 改行、タブ、連続する空白を単一のスペースに置き換える
+	text = strings.ReplaceAll(text, "\n", " ")
+	text = strings.ReplaceAll(text, "\t", " ")
+	text = strings.Join(strings.Fields(text), " ")
+	
+	// パディングを考慮して実際の利用可能幅を計算（左右1文字ずつのパディング）
+	availableWidth := width - 2
+	if availableWidth <= 0 {
+		return text
+	}
+	
+	// 表示幅を計算（全角文字は2、半角文字は1としてカウント）
+	textWidth := runewidth.StringWidth(text)
+	if textWidth <= availableWidth {
+		return text
+	}
+	
+	// "..."の表示幅（3文字）を確保
+	if availableWidth <= 3 {
+		return "..."
+	}
+	
+	// 利用可能な幅から"..."の分を引く
+	targetWidth := availableWidth - 3
+	
+	// 表示幅に基づいてテキストを切り詰める
+	truncated := runewidth.Truncate(text, targetWidth, "")
+	return truncated + "..."
 }

--- a/pkg/style.go
+++ b/pkg/style.go
@@ -118,10 +118,9 @@ func (s *Style) DescriptionStyle() lipgloss.Style {
 		PaddingRight(1)
 }
 
-// TruncateText truncates text to fit within the specified width
-// If text is longer than width, it will be truncated with "..." at the end
-// This function considers the display width (full-width characters count as 2)
-func TruncateText(text string, width int) string {
+// NormalizeAndFitText normalizes whitespace in text and fits it within the specified width
+// without adding ellipsis. Text is truncated if it exceeds the width.
+func NormalizeAndFitText(text string, width int) string {
 	// Normalize whitespace by replacing newlines, tabs, and multiple spaces with a single space.
 	text = strings.Join(strings.Fields(text), " ")
 
@@ -131,7 +130,6 @@ func TruncateText(text string, width int) string {
 		availableWidth = 0
 	}
 
-	// Truncate the text and add an ellipsis if it's too long.
-	// runewidth.Truncate handles cases where the text fits and does not need truncation.
-	return runewidth.Truncate(text, availableWidth, "...")
+	// Truncate the text to fit within available width (no ellipsis).
+	return runewidth.Truncate(text, availableWidth, "")
 }


### PR DESCRIPTION
Truncate table cell text to prevent wrapping and improve responsiveness within column boundaries.

---
<a href="https://cursor.com/background-agent?bcId=bc-d023a551-3071-40a7-8fb7-bd26465b0143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d023a551-3071-40a7-8fb7-bd26465b0143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Truncates header and row cell text with display-width awareness and sets MaxWidth on column styles to keep table cells within their columns.
> 
> - **Table formatting**:
>   - Add `TruncateText` in `pkg/style.go` using display-width (`go-runewidth`), normalizing whitespace and appending ellipsis.
>   - Apply truncation to header and data cells in `cmd/root.go` based on computed `columnWidths`.
>   - Enforce `MaxWidth` in `CommandStyle`, `ContentStyle`, and `DescriptionStyle` to prevent wrapping.
> - **Dependencies**:
>   - Import `github.com/mattn/go-runewidth` for width-aware truncation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c68ab1b1191e80e47a42975b2ff776a1dccb917d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->