### PR TITLE
Make table columns responsive within themselves

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -82,13 +82,13 @@ func run() {
 	// 利用可能なテーブル一覧を表示する
 	if listFlag {
 		fmt.Println("利用可能なテーブル一覧:")
-		
+
 		// 短縮コードの逆引きマップを作成（テーブル名から短縮コードを取得するため）
 		reverseMap := make(map[string][]string)
 		for code, name := range tableShortCodes {
 			reverseMap[name] = append(reverseMap[name], code)
 		}
-		
+
 		for key := range data {
 			if codes, ok := reverseMap[key]; ok && len(codes) > 0 {
 				// 短縮コードがある場合は表示
@@ -109,7 +109,7 @@ func run() {
 			table = strings.TrimSpace(table)
 			// 短縮コードをテーブル名に変換
 			expandedTable := expandTableCode(table)
-			
+
 			if datums, ok := data[expandedTable]; ok {
 				filteredData[expandedTable] = datums
 			} else {
@@ -143,28 +143,28 @@ func run() {
 			fmt.Print("\n") // 最小限の改行
 		}
 		isFirst = false
-		
+
 		style.SetTitle(key) // タイトルを設定
 		fmt.Print(style.ModeStyle().Render(key))
 		fmt.Print("\n")
 
 		// display header
 		headerCells := []string{
-			style.CommandStyle().Render(header[0]),
-			style.ContentStyle().Render(header[1]),
-			style.DescriptionStyle().Render(header[2]),
+			style.RenderCommand(header[0]),
+			style.RenderContent(header[1]),
+			style.RenderDescription(header[2]),
 		}
-		fmt.Print(lipgloss.JoinHorizontal(lipgloss.Left, headerCells...))
+		fmt.Print(lipgloss.JoinHorizontal(lipgloss.Top, headerCells...))
 		fmt.Print("\n")
 
 		// display data
 		for _, datum := range datums {
 			row := []string{
-				style.CommandStyle().Render(datum.Command),
-				style.ContentStyle().Render(datum.Content),
-				style.DescriptionStyle().Render(datum.Description),
+				style.RenderCommand(datum.Command),
+				style.RenderContent(datum.Content),
+				style.RenderDescription(datum.Description),
 			}
-			fmt.Print(lipgloss.JoinHorizontal(lipgloss.Left, row...))
+			fmt.Print(lipgloss.JoinHorizontal(lipgloss.Top, row...))
 			fmt.Print("\n")
 		}
 	}

--- a/pkg/table.go
+++ b/pkg/table.go
@@ -1,9 +1,10 @@
 package pkg
 
 import (
-	"math"
 	"os"
+	"strings"
 
+	"github.com/mattn/go-runewidth"
 	"golang.org/x/term"
 )
 
@@ -22,47 +23,110 @@ type ColumnWidths struct {
 // Width - returns the optimal widths for each column based on terminal width
 func (t *Table) Width(header []string, data Data) ColumnWidths {
 	termWidth, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil {
+	if err != nil || termWidth <= 0 {
 		termWidth = 80 // fallback width
 	}
 
-	// Calculate maximum content lengths for each column
-	maxCommand := len(header[0])
-	maxContent := len(header[1])
-	maxDesc := len(header[2])
+	paddingPerColumn := 2 // style padding: left+right
+	availableWidth := termWidth - (paddingPerColumn * 3)
+	if availableWidth < 3 {
+		availableWidth = 3
+	}
+
+	maxCommand := measureDisplayWidth(header[0])
+	maxContent := measureDisplayWidth(header[1])
+	maxDesc := measureDisplayWidth(header[2])
 
 	for _, items := range data {
 		for _, item := range items {
-			maxCommand = max(maxCommand, len(item.Command))
-			maxContent = max(maxContent, len(item.Content))
-			maxDesc = max(maxDesc, len(item.Description))
+			maxCommand = max(maxCommand, measureDisplayWidth(item.Command))
+			maxContent = max(maxContent, measureDisplayWidth(item.Content))
+			maxDesc = max(maxDesc, measureDisplayWidth(item.Description))
 		}
 	}
 
-	// Add padding and spacing between columns
-	spacing := 4 // 2 spaces on each side
-	availableWidth := termWidth - (spacing * 3) // space for 3 columns
+	minCommand := clampMinWidth(maxCommand, measureDisplayWidth(header[0]), 4)
+	minContent := clampMinWidth(maxContent, measureDisplayWidth(header[1]), 8)
+	minDesc := clampMinWidth(maxDesc, measureDisplayWidth(header[2]), 12)
 
-	// Minimum widths for each column (including padding)
-	minCommandWidth := min(maxCommand+spacing, int(float64(availableWidth)*0.2))
-	minContentWidth := min(maxContent+spacing, int(float64(availableWidth)*0.3))
-	minDescWidth := min(maxDesc+spacing, int(float64(availableWidth)*0.5))
+	widths := []int{
+		max(maxCommand, minCommand),
+		max(maxContent, minContent),
+		max(maxDesc, minDesc),
+	}
 
-	// Adjust widths if they exceed terminal width
-	totalWidth := minCommandWidth + minContentWidth + minDescWidth
-	if totalWidth > availableWidth {
-		// Scale down proportionally
-		ratio := float64(availableWidth) / float64(totalWidth)
-		minCommandWidth = int(math.Floor(float64(minCommandWidth) * ratio))
-		minContentWidth = int(math.Floor(float64(minContentWidth) * ratio))
-		minDescWidth = availableWidth - minCommandWidth - minContentWidth
+	total := widths[0] + widths[1] + widths[2]
+	limit := availableWidth
+	if limit <= 0 {
+		limit = total
+	}
+
+	minLimits := []int{minCommand, minContent, minDesc}
+	reductionOrder := []int{2, 1, 0} // prioritize shrinking description/content first
+
+	if total > limit {
+		for total > limit {
+			adjusted := false
+			for _, idx := range reductionOrder {
+				minAllowed := minLimits[idx]
+				if total > limit && widths[idx] > minAllowed {
+					widths[idx]--
+					total--
+					adjusted = true
+				}
+				if total <= limit {
+					break
+				}
+			}
+			if adjusted {
+				continue
+			}
+
+			for _, idx := range reductionOrder {
+				if total <= limit {
+					break
+				}
+				if widths[idx] > 1 {
+					widths[idx]--
+					total--
+					adjusted = true
+				}
+			}
+			if !adjusted {
+				break
+			}
+		}
 	}
 
 	return ColumnWidths{
-		Command:     minCommandWidth,
-		Content:     minContentWidth,
-		Description: minDescWidth,
+		Command:     max(widths[0], 1),
+		Content:     max(widths[1], 1),
+		Description: max(widths[2], 1),
 	}
+}
+
+func measureDisplayWidth(value string) int {
+	if value == "" {
+		return 0
+	}
+
+	clean := strings.ReplaceAll(value, "\t", "    ")
+	maxWidth := 0
+	for _, line := range strings.Split(clean, "\n") {
+		lineWidth := runewidth.StringWidth(line)
+		if lineWidth > maxWidth {
+			maxWidth = lineWidth
+		}
+	}
+	return maxWidth
+}
+
+func clampMinWidth(maxValue, headerWidth, suggested int) int {
+	minWidth := max(headerWidth, suggested)
+	if maxValue > 0 && maxValue < minWidth {
+		return maxValue
+	}
+	return minWidth
 }
 
 func max(a, b int) int {

--- a/pkg/table.go
+++ b/pkg/table.go
@@ -65,23 +65,27 @@ func (t *Table) Width(header []string, data Data) ColumnWidths {
 	reductionOrder := []int{2, 1, 0} // prioritize shrinking description/content first
 
 	if total > limit {
+		// Phase 1: reduce down to minimum limits
 		for total > limit {
-			adjusted := false
+			reduced := false
 			for _, idx := range reductionOrder {
-				minAllowed := minLimits[idx]
-				if total > limit && widths[idx] > minAllowed {
-					widths[idx]--
-					total--
-					adjusted = true
-				}
 				if total <= limit {
 					break
 				}
+				if widths[idx] > minLimits[idx] {
+					widths[idx]--
+					total--
+					reduced = true
+				}
 			}
-			if adjusted {
-				continue
+			if !reduced {
+				break
 			}
+		}
 
+		// Phase 2: reduce further if still exceeding limit
+		for total > limit {
+			reduced := false
 			for _, idx := range reductionOrder {
 				if total <= limit {
 					break
@@ -89,10 +93,10 @@ func (t *Table) Width(header []string, data Data) ColumnWidths {
 				if widths[idx] > 1 {
 					widths[idx]--
 					total--
-					adjusted = true
+					reduced = true
 				}
 			}
-			if !adjusted {
+			if !reduced {
 				break
 			}
 		}


### PR DESCRIPTION
テーブルの各カラム内でテキストを折り返し、端末幅に応じて列幅を動的に調整することで、可読性を向上させ表示崩れを防止します。

以前は、カラム内のテキストが長すぎると次の行の先頭に折り返され、テーブルが読みにくくなっていました。この変更により、テキストは自身のカラム内で適切に折り返され、`lipgloss.JoinHorizontal(lipgloss.Top)` を使用して複数行のセルも正しく揃うようになります。

---
<a href="https://cursor.com/background-agent?bcId=bc-d5042b05-306a-430e-a0e6-276878f6775e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d5042b05-306a-430e-a0e6-276878f6775e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps cell text within columns and computes display-aware responsive widths, updating rendering to align multi-line cells.
> 
> - **Table rendering**:
>   - Use `lipgloss.JoinHorizontal(lipgloss.Top)` and new `style.Render*` helpers to align multi-line cells in `cmd/root.go`.
> - **Styling**:
>   - Add `RenderCommand|Content|Description` that wrap text per column width; remove fixed `Width` from styles in `pkg/style.go`.
>   - Implement display-width-aware wrapping/padding (`wrapText`, `wrapLine`, `padLine`) using `go-runewidth`.
> - **Column width calculation**:
>   - Rework responsive width logic in `pkg/table.go` to consider terminal width, style padding, and the max display width of content/headers.
>   - Add `measureDisplayWidth` and `clampMinWidth`; shrink columns by priority (description → content → command) with safe fallbacks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2353caaa6a2194b2795eca1b24c2c103412c0336. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->